### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -15,15 +15,15 @@ set -g FISH_GIT_PROMPT_BEHIND_REMOTE "$magenta<$normal"
 set -g FISH_GIT_PROMPT_DIVERGED_REMOTE "$red<>$normal"
 
 function _git_branch_name -d "Display current branch's name"
-  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+  echo (command git symbolic-ref HEAD 2> /dev/null | sed -e 's|^refs/heads/||')
 end
 
 function _git_short_sha -d "Display short hash"
-    echo (command git rev-parse --short HEAD ^/dev/null)
+    echo (command git rev-parse --short HEAD 2> /dev/null)
 end
 
 function _git_ahead -d "git repository is ahead or behind origin"
-  set -l commits (command git rev-list --left-right '@{upstream}...HEAD' ^/dev/null)
+  set -l commits (command git rev-list --left-right '@{upstream}...HEAD' 2> /dev/null)
 
   if [ $status != 0 ]
     return
@@ -48,11 +48,11 @@ end
 
 function fish_prompt
     set -l cwd $green(basename (prompt_pwd))
-    if [ (command git rev-parse --git-dir ^/dev/null) ]
+    if [ (command git rev-parse --git-dir 2> /dev/null) ]
         set -l git_branch $yellow(_git_branch_name)
         set -l git_sha $magenta(_git_short_sha)$normal
         set -l git_branch_ahead (_git_ahead)
-        
+
         set git_info "$green($git_branch#$normal$git_sha$green)$normal $git_branch_ahead"
     end
 

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -24,7 +24,7 @@ set -g FISH_GIT_PROMPT_UNTRACKED "$cyan✭$normal"
 set -g FISH_GIT_PROMPT_CLEAN "$green✔$normal"
 
 function _git_status -d "git repo status about Untracked, new file and so on."
-    if [ (command git rev-parse --git-dir ^/dev/null) ]
+    if [ (command git rev-parse --git-dir 2> /dev/null) ]
         if [ (command git status | grep -c "working directory clean") -eq 1 ]
             echo "$FISH_GIT_PROMPT_CLEAN"
         else
@@ -50,7 +50,7 @@ end
 
 
 function _git_time_since_commit -d "Display the time since last commit"
-    if [ (command git rev-parse --git-dir ^/dev/null) ]
+    if [ (command git rev-parse --git-dir 2> /dev/null) ]
         # Only proceed if there is actually a commit.
         if [ (command git log 2>&1 > /dev/null | grep -c "^fatal:") -eq 0 ]
             # Get the last commit.


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618